### PR TITLE
fix tickets url in mobile hamburger menu

### DIFF
--- a/src/components/shared/mobile-menu/mobile-menu.jsx
+++ b/src/components/shared/mobile-menu/mobile-menu.jsx
@@ -69,7 +69,7 @@ const MobileMenu = ({ isOpen, onButtonClick }) => {
               alignItems: 'center',
             }}
             onClick={() =>
-              window.open('https://cnsmunich.ticketbutler.io/en/e/cnsmunich-2025/', '_blank')
+              window.open('https://dutch-cloud-native-day-2025.eventbrite.nl/', '_blank')
             }
           >
             Get your Ticket


### PR DESCRIPTION
Fix the url to buy tickets from the hamburger menu on mobile devices.
<img width="562" alt="Screenshot 2025-06-07 at 10 20 33" src="https://github.com/user-attachments/assets/91c2b995-f8f1-4399-a7c0-d013df815701" />
