### PR TITLE
updated sponsorship prospectus

### DIFF
--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -58,7 +58,7 @@ const Hero = () => {
                  Submit a Talk
                 </a>
                 <a
-                  href="https://drive.google.com/file/d/1LaEV0V7Qb4eIWn60K_dMuaKCfcf-cZSE/view"
+                  href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="button"

--- a/src/components/pages/home/sponsors/sponsors.jsx
+++ b/src/components/pages/home/sponsors/sponsors.jsx
@@ -310,7 +310,7 @@ const Sponsors = () => {
           <div className="flex flex-col items-center justify-center gap-4">
             <div className="flex flex-wrap items-center justify-center gap-4">
               <a
-                href="https://drive.google.com/file/d/1LaEV0V7Qb4eIWn60K_dMuaKCfcf-cZSE/view"
+                href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="button"
@@ -347,7 +347,7 @@ const Sponsors = () => {
         </p>
         <div className="flex flex-col items-center justify-center gap-4">
           <a
-            href="https://drive.google.com/file/d/1hbDPRG4_WNLUFIM2aHEOmD-jvno1356p/view?usp=sharing"
+            href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-lg bg-primary-1 px-6 py-3 text-white transition-all"


### PR DESCRIPTION
This pull request updates several Google Drive links used for call-to-action buttons on the home page, ensuring that all references point to the correct and current document. The changes affect both the "Submit a Talk" and sponsor-related buttons.

**Link updates:**

* Updated the  Sponsor button in `hero.jsx` to use the latest Google Drive document link.
* Updated two sponsor-related buttons in `sponsors.jsx` to point to the new shared Google Drive document, replacing outdated links. [[1]](diffhunk://#diff-a25a6f75f96ab52334e8813416ec18e8d4c977b8e79690538d5cf60980a72e54L313-R313) [[2]](diffhunk://#diff-a25a6f75f96ab52334e8813416ec18e8d4c977b8e79690538d5cf60980a72e54L350-R350)