### PR TITLE
Improve homepage content and ticket checkout

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,12 +5,13 @@ require('dotenv').config();
 module.exports = {
   flags: { DEV_SSR: process.env.GATSBY_DEV_SSR || false },
   siteMetadata: {
-    siteTitle: 'Pixel Point Gatsby Tailwind Starter',
-    siteDescription: 'Site Description',
+    siteTitle: 'Dutch Cloud Native Day 2026',
+    siteDescription:
+      'A two-day community-organized cloud native conference in Utrecht on 29 and 30 October 2026.',
     siteImage: '/images/social-preview.jpg',
     siteLanguage: 'en',
     siteUrl: process.env.GATSBY_DEFAULT_SITE_URL || 'http://localhost:8000',
-    authorName: 'Pixel Point',
+    authorName: 'Dutch Cloud Native Day',
   },
   plugins: [
     {
@@ -42,8 +43,8 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
-        name: 'gatsby-starter-default',
-        short_name: 'starter',
+        name: 'Dutch Cloud Native Day',
+        short_name: 'DCND',
         start_url: '/',
         display: 'minimal-ui',
         icon: 'src/images/favicon.png',

--- a/src/components/pages/home/eventbrite-checkout-button.jsx
+++ b/src/components/pages/home/eventbrite-checkout-button.jsx
@@ -1,0 +1,53 @@
+import React, { useRef, useState } from 'react';
+
+import { EVENTBRITE_EVENT_ID, EVENTBRITE_TICKETS_URL, loadEventbriteWidget } from './eventbrite';
+
+const EventbriteCheckoutButton = ({ className, children, triggerId }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const isInitialized = useRef(false);
+
+  const handleCheckoutClick = () => {
+    if (isInitialized.current || isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    loadEventbriteWidget(() => {
+      if (!window.EBWidgets) {
+        window.location.href = EVENTBRITE_TICKETS_URL;
+        return;
+      }
+
+      window.EBWidgets.createWidget({
+        widgetType: 'checkout',
+        eventId: EVENTBRITE_EVENT_ID,
+        modal: true,
+        modalTriggerElementId: triggerId,
+        onOrderComplete: () => {},
+      });
+
+      isInitialized.current = true;
+      setIsLoading(false);
+
+      window.requestAnimationFrame(() => {
+        document.getElementById(triggerId)?.click();
+      });
+    });
+  };
+
+  return (
+    <>
+      <noscript>
+        <a href={EVENTBRITE_TICKETS_URL} rel="noopener noreferrer" target="_blank">
+          Buy Tickets on Eventbrite
+        </a>
+      </noscript>
+      <button id={triggerId} type="button" className={className} onClick={handleCheckoutClick}>
+        {isLoading ? 'Loading checkout...' : children}
+      </button>
+    </>
+  );
+};
+
+export default EventbriteCheckoutButton;

--- a/src/components/pages/home/eventbrite.js
+++ b/src/components/pages/home/eventbrite.js
@@ -1,6 +1,8 @@
 export const EVENTBRITE_EVENT_ID = '1988815582946';
 export const EVENTBRITE_WIDGET_SCRIPT_ID = 'eventbrite-widget-script';
-export const EVENTBRITE_WIDGET_SCRIPT_SRC = 'https://www.eventbrite.nl/static/widgets/eb_widgets.js';
+export const EVENTBRITE_WIDGET_SCRIPT_SRC =
+  'https://www.eventbrite.nl/static/widgets/eb_widgets.js';
+export const EVENTBRITE_TICKETS_URL = `https://www.eventbrite.nl/e/dutch-cloud-native-day-2026-tickets-${EVENTBRITE_EVENT_ID}`;
 
 export const loadEventbriteWidget = (onLoad) => {
   const existingScript = document.getElementById(EVENTBRITE_WIDGET_SCRIPT_ID);

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -1,126 +1,96 @@
 import { StaticImage } from 'gatsby-plugin-image';
 import { Calendar, MapPin, Users } from 'lucide-react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import './hero.css';
 
-import { EVENTBRITE_EVENT_ID, loadEventbriteWidget } from '../eventbrite';
+const Hero = () => (
+  <div className="hero-container">
+    <section className="hero-section">
+      <div className="hero-background-grid" />
 
-const EVENTBRITE_MODAL_TRIGGER_ID = `eventbrite-widget-modal-trigger-${EVENTBRITE_EVENT_ID}`;
-const EVENTBRITE_TICKETS_URL = `https://www.eventbrite.nl/e/dutch-cloud-native-day-2026-tickets-${EVENTBRITE_EVENT_ID}`;
+      <div className="hero-content-container">
+        <div className="hero-grid">
+          {/* Left column - Content */}
+          <div className="hero-left-column fade-in-up">
+            {/* Date Badge */}
+            <span className="hero-badge">29 &amp; 30 October 2026</span>
 
-const Hero = () => {
-  useEffect(() => {
-    const createEventbriteModal = () => {
-      if (!window.EBWidgets) {
-        return;
-      }
+            {/* Title */}
+            <h1 className="hero-title">Dutch Cloud Native Day</h1>
 
-      window.EBWidgets.createWidget({
-        widgetType: 'checkout',
-        eventId: EVENTBRITE_EVENT_ID,
-        modal: true,
-        modalTriggerElementId: EVENTBRITE_MODAL_TRIGGER_ID,
-        onOrderComplete: () => {},
-      });
-    };
+            {/* Description */}
+            <p className="hero-description">
+              On 29 and 30 October 2026, the cloud native community will gather at Jaarbeurs in
+              Utrecht for two full days of talks, workshops and hallway conversations. Come and join
+              us!
+            </p>
 
-    return loadEventbriteWidget(createEventbriteModal);
-  }, []);
+            {/* Feature List */}
+            <ul className="hero-feature-list">
+              <li className="hero-feature-item">
+                <Calendar className="hero-icon" />
+                <span>29 October workshops, 30 October conference talks</span>
+              </li>
+              <li className="hero-feature-item">
+                <MapPin className="hero-icon" />
+                <span>Jaarbeurs, Utrecht, The Netherlands</span>
+              </li>
+              <li className="hero-feature-item">
+                <Users className="hero-icon" />
+                <span>Developers, Platform Engineers, AI Wizards and Cloud Native Enthusiasts</span>
+              </li>
+            </ul>
 
-  return (
-    <div className="hero-container">
-      <section className="hero-section">
-        <div className="hero-background-grid" />
-
-        <div className="hero-content-container">
-          <div className="hero-grid">
-            {/* Left column - Content */}
-            <div className="hero-left-column fade-in-up">
-              {/* Date Badge */}
-              <span className="hero-badge">29 &amp; 30 October 2026</span>
-
-              {/* Title */}
-              <h1 className="hero-title">Dutch Cloud Native Day</h1>
-
-              {/* Description */}
-              <p className="hero-description">
-                On 29 and 30 October 2026, the cloud native community will gather at Jaarbeurs in
-                Utrecht for two full days of talks, workshops and hallway conversations. Come and
-                join us!
-              </p>
-
-              {/* Feature List */}
-              <ul className="hero-feature-list">
-                <li className="hero-feature-item">
-                  <Calendar className="hero-icon" />
-                  <span>Two full days of technical talks and workshops</span>
-                </li>
-                <li className="hero-feature-item">
-                  <MapPin className="hero-icon" />
-                  <span>Jaarbeurs, Utrecht — The Netherlands</span>
-                </li>
-                <li className="hero-feature-item">
-                  <Users className="hero-icon" />
-                  <span>Developers, Platform Engineers, AI Wizards and Cloud Native Enthusiasts</span>
-                </li>
-              </ul>
-
-              <p className="hero-description">
-                After a great 2025 edition in Utrecht, Dutch Cloud Native Day returns in 2026. See
-                you there!
-              </p>
-              {/* CTA Buttons */}
-              <div className="hero-cta-container">
-                <a
-                  href="https://sessionize.com/dutch-cloud-native-day-2026/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hero-cta-button"
-                >
-                  Submit a Talk
-                </a>
-                <a
-                  href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hero-cta-button"
-                >
-                  Become a Sponsor
-                </a>
-                <noscript>
-                  <a href={EVENTBRITE_TICKETS_URL} rel="noopener noreferrer" target="_blank">
-                    Buy Tickets on Eventbrite
-                  </a>
-                </noscript>
-                <button id={EVENTBRITE_MODAL_TRIGGER_ID} type="button" className="hero-cta-button">
-                  Buy Tickets
-                </button>
-              </div>
+            <p className="hero-description">
+              After a great 2025 edition in Utrecht, Dutch Cloud Native Day returns in 2026. See you
+              there!
+            </p>
+            {/* CTA Buttons */}
+            <div className="hero-cta-container">
+              <a
+                href="https://sessionize.com/dutch-cloud-native-day-2026/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hero-cta-button"
+              >
+                Submit a Talk
+              </a>
+              <a
+                href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hero-cta-button"
+              >
+                Become a Sponsor
+              </a>
+              <a href="/#tickets" className="hero-cta-button">
+                Buy Tickets
+              </a>
             </div>
+          </div>
 
-            <div className="hero-right-column fade-in-scale">
-              <div className="hero-illustration-container">
-                <div
-                  style={{
-                    position: 'relative',
-                    aspectRatio: '0.8',
-                    borderRadius: '0.75rem',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <StaticImage
-                    src="./images/CND-NL-Buildings.png"
-                    alt="Dutch Cloud Native Day illustration"
-                    formats={['auto', 'webp']}
-                  />
-                </div>
+          <div className="hero-right-column fade-in-scale">
+            <div className="hero-illustration-container">
+              <div
+                style={{
+                  position: 'relative',
+                  aspectRatio: '0.8',
+                  borderRadius: '0.75rem',
+                  overflow: 'hidden',
+                }}
+              >
+                <StaticImage
+                  src="./images/CND-NL-Buildings.png"
+                  alt="Dutch Cloud Native Day illustration"
+                  formats={['auto', 'webp']}
+                />
               </div>
             </div>
           </div>
         </div>
-      </section>
-    </div>
-  );
-};
+      </div>
+    </section>
+  </div>
+);
 
 export default Hero;

--- a/src/components/pages/home/info/info.css
+++ b/src/components/pages/home/info/info.css
@@ -14,7 +14,7 @@
   font-weight: 700;
   color: #000;
   margin-bottom: 2.5rem;
-  color: #21468B;
+  color: #21468b;
 }
 
 /* About Section */
@@ -30,7 +30,7 @@
 /* Features Grid */
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 2rem;
   margin-top: 3rem;
 }
@@ -57,7 +57,7 @@
   font-weight: 600;
   color: #000;
   margin-bottom: 0.5rem;
-  color: #21468B;
+  color: #21468b;
 }
 
 .feature-text {

--- a/src/components/pages/home/info/info.jsx
+++ b/src/components/pages/home/info/info.jsx
@@ -1,4 +1,4 @@
-import { Users, Calendar, MapPin } from 'lucide-react';
+import { Calendar, Coffee, Mic2, Users } from 'lucide-react';
 import React from 'react';
 import './info.css';
 
@@ -12,8 +12,9 @@ const Info = () => (
         <div className="about-content">
           <div className="about-text">
             <p>
-              Dutch Cloud Native Day is a local (and International), community-organized event that gathers
-              adopters and technologists from open source and cloud native communities.
+              Dutch Cloud Native Day is a community-organized event for cloud native adopters,
+              technologists, platform engineers and open source practitioners from the Netherlands,
+              Europe and beyond.
             </p>
             <div className="text-start">
               <button
@@ -30,10 +31,9 @@ const Info = () => (
           </div>
           <div className="about-text">
             <p>
-              This is the 3rd edition of DCND in the Netherlands, aiming to bring the community together. The
-              event provides a platform for professionals and experts from all levels and
-              backgrounds to learn, network, and share their knowledge about cloud native
-              technologies.
+              The event is supported by Stichting Cloud Native Netherlands and remains vendor
+              neutral, inclusive and community first. Expect practical content, open CFP sessions
+              and space to meet peers across the cloud native ecosystem.
             </p>
           </div>
         </div>
@@ -44,37 +44,48 @@ const Info = () => (
 
       {/* What to Expect Section */}
       <div className="expect-section">
-        <h2 className="section-title">What to Expect?</h2>
+        <h2 className="section-title">What's included</h2>
         <div className="features-grid">
-          <div className="feature-item">
-            <Users className="feature-icon" />
-            <div className="feature-content">
-              <h3 className="feature-title">Community Networking</h3>
-              <p className="feature-text">Connect with peers from the cloud native community</p>
-            </div>
-          </div>
-
           <div className="feature-item">
             <Calendar className="feature-icon" />
             <div className="feature-content">
-              <h3 className="feature-title">Technical Talks</h3>
-              <p className="feature-text">Engaging presentations from industry experts</p>
+              <h3 className="feature-title">Workshop day</h3>
+              <p className="feature-text">Hands-on sessions planned for Thursday 29 October</p>
             </div>
           </div>
 
           <div className="feature-item">
-            <MapPin className="feature-icon" />
+            <Mic2 className="feature-icon" />
             <div className="feature-content">
-              <h3 className="feature-title">Unique Venue</h3>
+              <h3 className="feature-title">Conference day</h3>
               <p className="feature-text">
-                A fantastic multi-room venue with ample space for activities
+                Practical talks selected through the open CFP on Friday 30 October
+              </p>
+            </div>
+          </div>
+
+          <div className="feature-item">
+            <Coffee className="feature-icon" />
+            <div className="feature-content">
+              <h3 className="feature-title">Food included</h3>
+              <p className="feature-text">
+                Vegetarian and vegan-friendly catering during the conference day
+              </p>
+            </div>
+          </div>
+
+          <div className="feature-item">
+            <Users className="feature-icon" />
+            <div className="feature-content">
+              <h3 className="feature-title">Community space</h3>
+              <p className="feature-text">
+                Hallway conversations, sponsors and a welcoming vendor-neutral crowd
               </p>
             </div>
           </div>
         </div>
       </div>
       {/* What to Expect Section */}
-
     </div>
   </section>
 );

--- a/src/components/pages/home/sponsors/sponsors.jsx
+++ b/src/components/pages/home/sponsors/sponsors.jsx
@@ -330,9 +330,6 @@ const Sponsors = () => {
       <section className="mx-auto max-w-7xl px-4 py-16">
         <div className="mb-16 text-center">
           <h2 className="mb-4 text-4xl font-bold text-gray-900">Become a Sponsor</h2>
-          <p className="mb-8 text-lg text-gray-500">
-            Support our local cloud native community by sponsoring Dutch Cloud Native Day
-          </p>
 
           <div className="flex flex-col items-center justify-center gap-4">
             <div className="flex flex-wrap items-center justify-center gap-4">
@@ -345,7 +342,18 @@ const Sponsors = () => {
               >
                 Sponsorship Prospectus
               </a>
+              <a
+                href={`mailto:${contactEmail}?subject=Dutch%20Cloud%20Native%20Day%202026%20sponsorship`}
+                className="button"
+                style={{ cursor: 'pointer', textDecoration: 'none' }}
+              >
+                Become a Sponsor
+              </a>
             </div>
+            <p className="text-lg text-gray-500">
+              Support our local cloud native community and help make Dutch Cloud Native Day
+              possible.
+            </p>
             <p className="text-sm text-gray-600">
               Contact us at{' '}
               <a
@@ -429,19 +437,27 @@ const Sponsors = () => {
 
       <div className="mt-12 text-center">
         <h3 className="mb-4 text-2xl font-bold text-gray-900">Become a Sponsor</h3>
-        <p className="mb-8 text-lg text-gray-500">
-          Support our local cloud native community and help make Dutch Cloud Native Day possible.
-        </p>
 
         <div className="flex flex-col items-center justify-center gap-4">
-          <a
-            href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-lg bg-primary-1 px-6 py-3 text-white transition-all"
-          >
-            Sponsorship Prospectus
-          </a>
+          <div className="flex flex-wrap items-center justify-center gap-4">
+            <a
+              href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-primary-1 px-6 py-3 text-white transition-all"
+            >
+              Sponsorship Prospectus
+            </a>
+            <a
+              href={`mailto:${contactEmail}?subject=Dutch%20Cloud%20Native%20Day%202026%20sponsorship`}
+              className="inline-flex items-center gap-2 rounded-lg bg-primary-1 px-6 py-3 text-white transition-all"
+            >
+              Become a Sponsor
+            </a>
+          </div>
+          <p className="text-lg text-gray-500">
+            Support our local cloud native community and help make Dutch Cloud Native Day possible.
+          </p>
           <p className="text-sm text-gray-600">
             Contact us at{' '}
             <a

--- a/src/components/pages/home/tickets/tickets.css
+++ b/src/components/pages/home/tickets/tickets.css
@@ -9,10 +9,56 @@
 }
 
 .tickets-card {
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background: #fff;
+}
+
+.tickets-card-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.tickets-card-content h3 {
+  color: #21468b;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.tickets-card-content p {
+  color: #666;
+  font-size: 1rem;
+}
+
+.tickets-checkout-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0.75rem 1.5rem;
+  color: #fff;
+  font-weight: 700;
+  background: #ff7900;
+  border-radius: 0.375rem;
+}
+
+.tickets-privacy-note {
+  max-width: 640px;
+  font-size: 0.875rem !important;
+}
+
+.tickets-privacy-note a {
+  color: #21468b;
+  font-weight: 700;
+}
+
+.tickets-privacy-note a:hover {
+  text-decoration: underline;
 }
 
 .diversity-ticket-card {

--- a/src/components/pages/home/tickets/tickets.jsx
+++ b/src/components/pages/home/tickets/tickets.jsx
@@ -1,36 +1,38 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import './tickets.css';
 
-import { EVENTBRITE_EVENT_ID, loadEventbriteWidget } from '../eventbrite';
-
-const EVENTBRITE_WIDGET_CONTAINER_ID = `eventbrite-widget-container-${EVENTBRITE_EVENT_ID}`;
+import EventbriteCheckoutButton from '../eventbrite-checkout-button';
 
 const Tickets = () => {
-  useEffect(() => {
-    const createEventbriteWidget = () => {
-      if (!window.EBWidgets) {
-        return;
-      }
-
-      window.EBWidgets.createWidget({
-        widgetType: 'checkout',
-        eventId: EVENTBRITE_EVENT_ID,
-        iframeContainerId: EVENTBRITE_WIDGET_CONTAINER_ID,
-        iframeContainerHeight: 425,
-        onOrderComplete: () => {},
-      });
-    };
-
-    return loadEventbriteWidget(createEventbriteWidget);
-  }, []);
-
   return (
     <section className="tickets-section" id="tickets">
       <div className="tickets-container">
         <h2 className="section-title">Tickets</h2>
 
         <div className="tickets-card">
-          <div id={EVENTBRITE_WIDGET_CONTAINER_ID} />
+          <div className="tickets-card-content">
+            <h3>Dutch Cloud Native Day 2026</h3>
+            <p>Tickets are handled by Eventbrite in a secure checkout window.</p>
+            <EventbriteCheckoutButton
+              triggerId="eventbrite-ticket-section-checkout-trigger"
+              className="tickets-checkout-button"
+            >
+              Buy Tickets
+            </EventbriteCheckoutButton>
+            <p className="tickets-privacy-note">
+              Ticket checkout is handled by Eventbrite. When you continue, Eventbrite may process
+              your personal data and use cookies or similar technologies for checkout, payment,
+              security, analytics, and related services. See{' '}
+              <a
+                href="https://www.eventbrite.com/help/en-us/articles/460838/eventbrite-privacy-policy/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Eventbrite's privacy and cookie information
+              </a>
+              .
+            </p>
+          </div>
         </div>
 
         <div className="diversity-ticket-card">

--- a/src/components/pages/home/venue/venue.jsx
+++ b/src/components/pages/home/venue/venue.jsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, Users, Calendar, MapPin } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import React, { useState, useEffect } from 'react';
 
 import venue1 from './images/DCND-RM-008.jpg';
@@ -11,7 +11,6 @@ import venue7 from './images/DCND-RM-185.jpg';
 import venue8 from './images/DCND-YM-19.jpg';
 import venue9 from './images/DCND-YM-150.jpg';
 
-// Icons aus dem ursprünglichen Code
 const IconMapPin = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -26,83 +25,6 @@ const IconMapPin = () => (
   >
     <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
     <circle cx="12" cy="10" r="3" />
-  </svg>
-);
-
-const IconUtensils = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2" />
-    <path d="M7 2v20" />
-    <path d="M21 15V2v0a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7" />
-  </svg>
-);
-
-const IconClock = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="12" cy="12" r="10" />
-    <polyline points="12 6 12 12 16 14" />
-  </svg>
-);
-
-const IconParty = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M5.8 11.3 2 22l10.7-3.79" />
-    <path d="M4 3h.01" />
-    <path d="M22 8h.01" />
-    <path d="M15 2h.01" />
-    <path d="M22 20h.01" />
-    <path d="m22 2-2.24.75a2.9 2.9 0 0 0-1.96 3.12v0c.1.86-.57 1.63-1.45 1.63h-.38c-.86 0-1.6.6-1.76 1.44L14 10" />
-    <path d="m22 13-.82-.33c-.86-.34-1.82.2-1.98 1.11v0c-.11.7-.72 1.22-1.43 1.22H17" />
-    <path d="m11 2 .33.82c.34.86-.2 1.82-1.11 1.98v0C9.52 4.9 9 5.52 9 6.23V7" />
-    <path d="M11 13c1.93 1.93 2.83 4.17 2 5-.83.83-3.07-.07-5-2-1.93-1.93-2.83-4.17-2-5 .83-.83 3.07.07 5 2Z" />
-  </svg>
-);
-
-const IconExternal = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-    <polyline points="15 3 21 3 21 9" />
-    <line x1="10" y1="14" x2="21" y2="3" />
   </svg>
 );
 
@@ -158,8 +80,9 @@ const ImageSlider = ({ images }) => {
         <img
           src={images[currentImageIndex]}
           alt={`Venue slide ${currentImageIndex + 1}`}
-          className={`h-full w-full object-cover transition-opacity duration-500 ${fade ? 'opacity-0' : 'opacity-100'
-            }`}
+          className={`h-full w-full object-cover transition-opacity duration-500 ${
+            fade ? 'opacity-0' : 'opacity-100'
+          }`}
         />
 
         {/* Navigation Dots */}
@@ -168,8 +91,9 @@ const ImageSlider = ({ images }) => {
             <button
               type="button"
               key={index}
-              className={`h-2 w-2 rounded-full ${index === currentImageIndex ? 'bg-white' : 'bg-white/50'
-                }`}
+              className={`h-2 w-2 rounded-full ${
+                index === currentImageIndex ? 'bg-white' : 'bg-white/50'
+              }`}
               onClick={() => setCurrentImageIndex(index)}
             />
           ))}
@@ -195,17 +119,7 @@ const ImageSlider = ({ images }) => {
   );
 };
 
-const VENUE_IMAGES = [
-  venue1,
-  venue2,
-  venue3,
-  venue4,
-  venue5,
-  venue6,
-  venue7,
-  venue8,
-  venue9,
-];
+const VENUE_IMAGES = [venue1, venue2, venue3, venue4, venue5, venue6, venue7, venue8, venue9];
 
 const Venue = () => {
   const images = VENUE_IMAGES;
@@ -249,35 +163,6 @@ const Venue = () => {
               </a>
             </div>
           </Card>
-        </div>
-
-        {/* What to Expect Section */}
-        <div className="expect-section">
-          <div className="features-grid justify-items-center md:justify-items-start">
-            <div className="feature-item">
-              <Users className="feature-icon" />
-              <div className="feature-content">
-                <h3 className="feature-title">Catering</h3>
-                <p className="feature-text">Vegetarian & Vegan options</p>
-              </div>
-            </div>
-
-            <div className="feature-item">
-              <Calendar className="feature-icon" />
-              <div className="feature-content">
-                <h3 className="feature-title">2-Day Event</h3>
-                <p className="feature-text">With many activities</p>
-              </div>
-            </div>
-
-            <div className="feature-item">
-              <MapPin className="feature-icon" />
-              <div className="feature-content">
-                <h3 className="feature-title">Networking Event</h3>
-                <p className="feature-text">Connect with your peers</p>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/src/components/pages/speakers/hero/hero.jsx
+++ b/src/components/pages/speakers/hero/hero.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-import Button from 'components/shared/button';
-
-const TITLE = 'Speaker Lineup';
-const DESCRIPTION = 'Meet our fantastic speakers and learn from their experience.';
+const TITLE = 'Call for Speakers';
+const DESCRIPTION =
+  'The Dutch Cloud Native Day 2026 CFP is open. Submit your talk or workshop proposal via Sessionize.';
 
 const Hero = () => (
   <section className="safe-paddings pb-10 pt-24 lg:pt-[4.5rem] md:pb-4 md:pt-16 sm:py-8">

--- a/src/components/pages/speakers/speakers/speakers.jsx
+++ b/src/components/pages/speakers/speakers/speakers.jsx
@@ -5,10 +5,10 @@ import './speakers.css';
 const Speakers = () => (
   <section className="py-16">
     <div className="container mx-auto max-w-2xl px-4 text-center">
-      <h1 className="mb-6 text-3xl font-bold text-primary-1">Speakers — 2026</h1>
-      <p className="text-gray-600">
-        The 2026 speaker lineup has not been announced yet. Submissions open soon via our Call for
-        Speakers — check back here, or browse the{' '}
+      <h1 className="mb-6 text-3xl font-bold text-primary-1">Submit a Talk for 2026</h1>
+      <p className="mb-8 text-gray-600">
+        The 2026 speaker lineup has not been announced yet because the Call for Speakers is open.
+        Share your cloud native talk or workshop proposal through Sessionize, or browse the{' '}
         <a
           href="/2025/speakers/"
           target="_blank"
@@ -19,6 +19,14 @@ const Speakers = () => (
         </a>{' '}
         for a taste of previous editions.
       </p>
+      <a
+        href="https://sessionize.com/dutch-cloud-native-day-2026/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center justify-center rounded-md bg-primary-1 px-6 py-3 font-bold text-white transition-colors hover:bg-blue-1"
+      >
+        Submit a Talk
+      </a>
     </div>
   </section>
 );

--- a/src/components/shared/footer/footer.css
+++ b/src/components/shared/footer/footer.css
@@ -1,9 +1,61 @@
 .Link {
-  color: #21468B;
+  color: #21468b;
   text-decoration: none;
 }
 
 .Link:hover {
-  color: #21468B; 
-  text-decoration: underline; 
+  color: #21468b;
+  text-decoration: underline;
+}
+
+.footer-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding-bottom: 1.25rem;
+  padding-top: 1.25rem;
+}
+
+.footer-nav-list {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.footer-nav-item {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.footer-contact {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-social-list {
+  display: flex;
+  min-width: fit-content;
+  gap: 0.625rem;
+}
+
+@media (max-width: 1023px) {
+  .footer-container {
+    flex-direction: column;
+    justify-content: center;
+    gap: 1.25rem;
+    text-align: center;
+  }
+
+  .footer-nav-list {
+    flex-wrap: wrap;
+    gap: 1rem 1.5rem;
+  }
+
+  .footer-contact {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
 }

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -51,7 +51,7 @@ const Footer = () => {
   };
   return (
     <footer className="safe-paddings border-t border-t-gray-10 bg-white">
-      <div className="container flex items-center justify-between gap-4 pb-5 pt-5 sm:flex-col sm:justify-around">
+      <div className="footer-container container">
         <Link className="z-50 ml-2" to="/">
           <StaticImage
             src="./images/logo.png"
@@ -61,27 +61,18 @@ const Footer = () => {
           />
         </Link>
 
-        <nav className="mt-4 flex">
-          <ul className="grid min-w-fit grid-cols-2 grid-rows-2 gap-x-3 gap-y-4 xl:gap-x-1 lg:mr-6 lg:gap-x-4 sm:mx-auto">
+        <nav className="footer-nav" aria-label="Footer navigation">
+          <ul className="footer-nav-list">
             {MENUS.footer.map(({ text, to, target }, index) => (
-              <li
-                className="w-fit max-w-min text-sm font-semibold"
-                key={index}
-                style={{ color: '#' }}
-              >
-                <Button
-                  className="Link flex sm:flex-wrap"
-                  to={to}
-                  target={target}
-                  onClick={handleAnchorClick}
-                >
+              <li className="footer-nav-item" key={index}>
+                <Button className="Link" to={to} target={target} onClick={handleAnchorClick}>
                   {text}
                 </Button>
               </li>
             ))}
           </ul>
         </nav>
-        <div className="mt-4">
+        <div className="footer-contact">
           <div className="flex h-full items-center justify-center">
             <Link
               className="Link ml-2 font-semibold transition-colors duration-200"
@@ -92,7 +83,7 @@ const Footer = () => {
             </Link>
           </div>
 
-          <ul className="mt-4 flex min-w-fit gap-x-2.5">
+          <ul className="footer-social-list">
             {items.map(({ icon, iconClassName, url }, index) => {
               const Icon = icon;
 

--- a/src/components/shared/mobile-menu/mobile-menu.jsx
+++ b/src/components/shared/mobile-menu/mobile-menu.jsx
@@ -88,7 +88,7 @@ const MobileMenu = ({ isOpen, onButtonClick }) => {
           </ul>
         </div>
         <div className="flex items-center justify-center">
-          <p className="text-center text-sm text-gray-500">Tickets for 2026 — coming soon</p>
+          <p className="text-center text-sm text-gray-500">Tickets for 2026 are available now</p>
         </div>
       </m.nav>
     </LazyMotion>

--- a/src/components/shared/seo/seo.jsx
+++ b/src/components/shared/seo/seo.jsx
@@ -2,9 +2,9 @@
 import { useStaticQuery, graphql } from 'gatsby';
 import React from 'react';
 
-const defaultTitle = 'DCND Utrecht';
+const defaultTitle = 'Dutch Cloud Native Day 2026';
 const defaultDescription =
-  'Experience the power of community at the Dutch Cloud Native Day Utrecht!';
+  'A two-day community-organized cloud native conference in Utrecht on 29 and 30 October 2026.';
 
 const SEO = ({ title, description, pathname }) => {
   const {

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -31,7 +31,12 @@ export default {
     to: '/team',
   },
   tickets: {
-    to: '',
+    to: `/#${getAnchor('tickets')}`,
+    id: getAnchor('tickets'),
+    homeTo: null,
+  },
+  cfp: {
+    to: 'https://sessionize.com/dutch-cloud-native-day-2026/',
     target: '_blank',
     external: true,
   },

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -2,6 +2,8 @@ import LINKS from 'constants/links.js';
 
 const MENUS = {
   header: [
+    { text: 'Tickets', ...LINKS.tickets },
+    { text: 'Submit a Talk', ...LINKS.cfp },
     { text: 'Sponsors', ...LINKS.sponsors },
     { text: 'Team', ...LINKS.team },
     {
@@ -10,13 +12,14 @@ const MENUS = {
     },
   ],
   footer: [
-    { text: 'Schedule', ...LINKS.schedule },
-    { text: 'Code of Conduct', ...LINKS.conduct },
-    { text: 'Team', ...LINKS.team },
     { text: 'Our Vision', ...LINKS.vision },
+    { text: 'Team', ...LINKS.team },
+    { text: 'Code of Conduct', ...LINKS.conduct },
     //{ text: 'Imprint & Data Privacy', ...LINKS.privacy },
   ],
   mobile: [
+    { text: 'Tickets', ...LINKS.tickets },
+    { text: 'Submit a Talk', ...LINKS.cfp },
     { text: 'Sponsors', ...LINKS.sponsors },
     { text: 'Team', ...LINKS.team },
     {


### PR DESCRIPTION
## Summary
- replace the auto-loaded Eventbrite embed with a delayed checkout button and privacy notice
- add Tickets and Submit a Talk navigation, update CFP/speakers messaging, and improve homepage copy
- simplify the footer and sponsor CTA layout

## Verification
- npm run build