### PR TITLE
Add GoatCounter analytics

### DIFF
--- a/content/static-pages/privacy.md
+++ b/content/static-pages/privacy.md
@@ -1,0 +1,9 @@
+---
+title: Privacy
+slug: privacy
+---
+
+## Analytics
+
+We use privacy-friendly, cookie-free analytics to understand aggregate website usage, such as page views, referrers, browser/device type, country-level location and clicks on important links such as ticket, CFP and sponsor buttons. We do not use this analytics setup to identify individual visitors, build user profiles, or track people across websites.
+We use GoatCounter, an open-source privacy-friendly analytics tool, for these aggregate statistics.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "NODE_NO_WARNINGS=1 gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
+    "test:analytics": "node scripts/test-goatcounter-analytics.mjs",
     "format": "prettier --write --ignore-path .gitignore .",
     "lint": "npm run lint:js & npm run lint:md",
     "lint:fix": "npm run lint:js:fix & npm run lint:md:fix",

--- a/scripts/test-goatcounter-analytics.mjs
+++ b/scripts/test-goatcounter-analytics.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const html = read('src/html.jsx');
+const hero = read('src/components/pages/home/hero/hero.jsx');
+const tickets = read('src/components/pages/home/tickets/tickets.jsx');
+const checkout = read('src/components/pages/home/eventbrite-embedded-checkout.jsx');
+const sponsors = read('src/components/pages/home/sponsors/sponsors.jsx');
+const footer = read('src/components/shared/footer/footer.jsx');
+const privacy = read('content/static-pages/privacy.md');
+const menus = read('src/constants/menus.js');
+
+assert.match(html, /Cookie-free aggregate analytics/);
+assert.match(html, /data-goatcounter="https:\/\/dcnd\.goatcounter\.com\/count"/);
+assert.match(html, /src="https:\/\/gc\.zgo\.at\/count\.js"/);
+
+[
+  ['ticket-click', 'Ticket click', `${hero}\n${tickets}`],
+  ['eventbrite-open', 'Eventbrite checkout opened', `${tickets}\n${checkout}`],
+  ['cfp-click', 'CFP click', hero],
+  ['sponsor-click', 'Sponsor click', `${hero}\n${sponsors}`],
+  ['contact-click', 'Contact click', `${tickets}\n${sponsors}\n${footer}`],
+].forEach(([path, title, source]) => {
+  assert.match(source, new RegExp(`data-goatcounter-click="${path}"`));
+  assert.match(source, new RegExp(`data-goatcounter-title="${title}"`));
+});
+
+assert.match(checkout, /window\.goatcounter/);
+assert.match(checkout, /typeof window\.goatcounter\.count === 'function'/);
+assert.match(checkout, /path: 'eventbrite-open'/);
+assert.match(checkout, /event: true/);
+
+assert.match(privacy, /privacy-friendly, cookie-free analytics/);
+assert.match(privacy, /We use GoatCounter, an open-source privacy-friendly analytics tool/);
+assert.match(menus, /Privacy/);

--- a/src/components/pages/home/eventbrite-embedded-checkout.jsx
+++ b/src/components/pages/home/eventbrite-embedded-checkout.jsx
@@ -4,6 +4,16 @@ import { EVENTBRITE_EVENT_ID, EVENTBRITE_TICKETS_URL, loadEventbriteWidget } fro
 
 const CHECKOUT_CONTAINER_ID = 'eventbrite-inline-checkout';
 
+const countEventbriteOpen = () => {
+  if (window.goatcounter && typeof window.goatcounter.count === 'function') {
+    window.goatcounter.count({
+      path: 'eventbrite-open',
+      title: 'Eventbrite checkout opened',
+      event: true,
+    });
+  }
+};
+
 const EventbriteEmbeddedCheckout = () => {
   const [status, setStatus] = useState('loading');
   const hasInitialized = useRef(false);
@@ -22,6 +32,7 @@ const EventbriteEmbeddedCheckout = () => {
       }
 
       hasInitialized.current = true;
+      countEventbriteOpen();
 
       window.EBWidgets.createWidget({
         widgetType: 'checkout',

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -52,6 +52,8 @@ const Hero = () => (
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hero-cta-button"
+                data-goatcounter-click="cfp-click"
+                data-goatcounter-title="CFP click"
               >
                 Submit a Talk
               </a>
@@ -60,10 +62,17 @@ const Hero = () => (
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hero-cta-button"
+                data-goatcounter-click="sponsor-click"
+                data-goatcounter-title="Sponsor click"
               >
                 Become a Sponsor
               </a>
-              <a href="/#tickets" className="hero-cta-button">
+              <a
+                href="/#tickets"
+                className="hero-cta-button"
+                data-goatcounter-click="ticket-click"
+                data-goatcounter-title="Ticket click"
+              >
                 Buy Tickets
               </a>
             </div>

--- a/src/components/pages/home/sponsors/sponsors.jsx
+++ b/src/components/pages/home/sponsors/sponsors.jsx
@@ -350,6 +350,8 @@ const Sponsors = () => {
                 rel="noopener noreferrer"
                 className="button"
                 style={{ cursor: 'pointer', textDecoration: 'none' }}
+                data-goatcounter-click="sponsor-click"
+                data-goatcounter-title="Sponsor click"
               >
                 Sponsorship Prospectus
               </a>
@@ -357,6 +359,8 @@ const Sponsors = () => {
                 href={`mailto:${contactEmail}?subject=Dutch%20Cloud%20Native%20Day%202026%20sponsorship`}
                 className="button"
                 style={{ cursor: 'pointer', textDecoration: 'none' }}
+                data-goatcounter-click="sponsor-click"
+                data-goatcounter-title="Sponsor click"
               >
                 Become a Sponsor
               </a>
@@ -371,6 +375,8 @@ const Sponsors = () => {
                 href={`mailto:${contactEmail}`}
                 className=" hover:underline"
                 style={{ color: '#21468B', fontWeight: 'bold' }}
+                data-goatcounter-click="contact-click"
+                data-goatcounter-title="Contact click"
               >
                 {contactEmail}
               </a>{' '}
@@ -422,6 +428,8 @@ const Sponsors = () => {
                     config.cardClass,
                     config.class
                   )}
+                  data-goatcounter-click="sponsor-click"
+                  data-goatcounter-title="Sponsor click"
                   style={{
                     width: config.cardWidth,
                     height: config.cardHeight,
@@ -456,12 +464,16 @@ const Sponsors = () => {
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-lg bg-primary-1 px-6 py-3 text-white transition-all"
+              data-goatcounter-click="sponsor-click"
+              data-goatcounter-title="Sponsor click"
             >
               Sponsorship Prospectus
             </a>
             <a
               href={`mailto:${contactEmail}?subject=Dutch%20Cloud%20Native%20Day%202026%20sponsorship`}
               className="inline-flex items-center gap-2 rounded-lg bg-primary-1 px-6 py-3 text-white transition-all"
+              data-goatcounter-click="sponsor-click"
+              data-goatcounter-title="Sponsor click"
             >
               Become a Sponsor
             </a>
@@ -475,6 +487,8 @@ const Sponsors = () => {
               href={`mailto:${contactEmail}`}
               className=" hover:underline"
               style={{ color: '#21468B', fontWeight: 'bold' }}
+              data-goatcounter-click="contact-click"
+              data-goatcounter-title="Contact click"
             >
               {contactEmail}
             </a>{' '}

--- a/src/components/pages/home/tickets/tickets.jsx
+++ b/src/components/pages/home/tickets/tickets.jsx
@@ -3,8 +3,8 @@ import './tickets.css';
 
 import { useCookieConsent } from 'components/shared/cookie-consent';
 
-import EventbriteEmbeddedCheckout from '../eventbrite-embedded-checkout';
 import { EVENTBRITE_TICKETS_URL } from '../eventbrite';
+import EventbriteEmbeddedCheckout from '../eventbrite-embedded-checkout';
 
 const Tickets = () => {
   const { hasTicketCheckoutConsent, openCookiePreferences } = useCookieConsent();
@@ -24,6 +24,8 @@ const Tickets = () => {
                 <button
                   type="button"
                   className="tickets-checkout-button"
+                  data-goatcounter-click="ticket-click"
+                  data-goatcounter-title="Ticket click"
                   onClick={openCookiePreferences}
                 >
                   Allow ticket checkout
@@ -33,6 +35,8 @@ const Tickets = () => {
                   href={EVENTBRITE_TICKETS_URL}
                   target="_blank"
                   rel="noopener noreferrer"
+                  data-goatcounter-click="eventbrite-open"
+                  data-goatcounter-title="Eventbrite checkout opened"
                 >
                   Open on Eventbrite
                 </a>
@@ -67,6 +71,8 @@ const Tickets = () => {
             <a
               href="mailto:info@dutchcloudnativeday.nl"
               className="text-primary font-bold hover:underline"
+              data-goatcounter-click="contact-click"
+              data-goatcounter-title="Contact click"
             >
               info@dutchcloudnativeday.nl
             </a>{' '}

--- a/src/components/shared/cookie-consent/cookie-consent.jsx
+++ b/src/components/shared/cookie-consent/cookie-consent.jsx
@@ -99,8 +99,9 @@ const CookieConsent = ({ children }) => {
           <div className="cookie-banner__content">
             <h2>Cookie choices</h2>
             <p>
-              Dutch Cloud Native Day does not use analytics or advertising cookies. We only load
-              Eventbrite when you allow the ticket checkout service.
+              Dutch Cloud Native Day uses cookie-free aggregate analytics and does not use
+              advertising cookies. We only load Eventbrite when you allow the ticket checkout
+              service.
             </p>
           </div>
           <div className="cookie-banner__actions">

--- a/src/components/shared/footer/footer.jsx
+++ b/src/components/shared/footer/footer.jsx
@@ -81,6 +81,8 @@ const Footer = () => {
               className="Link ml-2 font-semibold transition-colors duration-200"
               theme="primary"
               to="mailto:info@dutchcloudnativeday.nl"
+              data-goatcounter-click="contact-click"
+              data-goatcounter-title="Contact click"
             >
               Contact us
             </Link>

--- a/src/constants/links.js
+++ b/src/constants/links.js
@@ -50,6 +50,11 @@ export default {
     target: '_blank',
     external: true,
   },
+  privacy: {
+    to: '/privacy',
+    target: '_blank',
+    external: true,
+  },
   past2025: {
     to: '/2025/',
     target: '_blank',

--- a/src/constants/menus.js
+++ b/src/constants/menus.js
@@ -15,7 +15,7 @@ const MENUS = {
     { text: 'Our Vision', ...LINKS.vision },
     { text: 'Team', ...LINKS.team },
     { text: 'Code of Conduct', ...LINKS.conduct },
-    //{ text: 'Imprint & Data Privacy', ...LINKS.privacy },
+    { text: 'Privacy', ...LINKS.privacy },
   ],
   mobile: [
     { text: 'Tickets', ...LINKS.tickets },

--- a/src/html.jsx
+++ b/src/html.jsx
@@ -38,6 +38,12 @@ const HTML = ({
       {preBodyComponents}
       <div key="body" id="___gatsby" dangerouslySetInnerHTML={{ __html: body }} />
       {postBodyComponents}
+      {/* Cookie-free aggregate analytics. */}
+      <script
+        data-goatcounter="https://dcnd.goatcounter.com/count"
+        src="https://gc.zgo.at/count.js"
+        async
+      />
     </body>
   </html>
 );


### PR DESCRIPTION
- add hosted GoatCounter globally with the dcnd endpoint
- track ticket, Eventbrite, CFP, sponsor, and contact clicks
- add a privacy page note and footer link for cookie-free aggregate analytics
- add a source-level analytics regression test

### Tests

- npm run test:analytics
- npx prettier --check package.json src/html.jsx src/constants/links.js src/constants/menus.js src/components/pages/home/hero/hero.jsx src/components/pages/home/tickets/tickets.jsx src/components/pages/home/eventbrite-embedded-checkout.jsx src/components/pages/home/sponsors/sponsors.jsx src/components/shared/footer/footer.jsx src/components/shared/cookie-consent/cookie-consent.jsx content/static-pages/privacy.md scripts/test-goatcounter-analytics.mjs
- npm run build

Note: full npm run lint:js and npm run lint:md still fail on pre-existing repo issues outside this change.