### PR TITLE
Improve mobile hero buildings layout

### DIFF
--- a/content/static-pages/privacy.md
+++ b/content/static-pages/privacy.md
@@ -7,3 +7,9 @@ slug: privacy
 
 We use privacy-friendly, cookie-free analytics to understand aggregate website usage, such as page views, referrers, browser/device type, country-level location and clicks on important links such as ticket, CFP and sponsor buttons. We do not use this analytics setup to identify individual visitors, build user profiles, or track people across websites.
 We use GoatCounter, an open-source privacy-friendly analytics tool, for these aggregate statistics.
+
+## Tickets and Eventbrite
+
+We use Eventbrite for ticket checkout. The embedded Eventbrite checkout is loaded only after you allow the ticket checkout service in the cookie/settings banner. You can also use the fallback link to open Eventbrite directly.
+
+Eventbrite may process your personal data and use cookies or similar technologies for checkout, payment, security, analytics, and related services. See Eventbrite's privacy and cookie information for details.

--- a/scripts/test-goatcounter-analytics.mjs
+++ b/scripts/test-goatcounter-analytics.mjs
@@ -34,4 +34,6 @@ assert.match(checkout, /event: true/);
 
 assert.match(privacy, /privacy-friendly, cookie-free analytics/);
 assert.match(privacy, /We use GoatCounter, an open-source privacy-friendly analytics tool/);
+assert.match(privacy, /The embedded Eventbrite checkout is loaded only after you allow/);
+assert.match(privacy, /Eventbrite may process your personal data and use cookies/);
 assert.match(menus, /Privacy/);

--- a/src/components/pages/home/hero/hero.css
+++ b/src/components/pages/home/hero/hero.css
@@ -16,15 +16,21 @@
 /* Content Container */
 .hero-content-container {
   position: relative;
-  padding: 4rem 1rem;
+  padding: 0.25rem 1rem 3rem;
   margin: 0 auto;
   max-width: 80rem;
+}
+
+@media (min-width: 1024px) {
+  .hero-content-container {
+    padding: 4rem 1rem;
+  }
 }
 
 /* Grid Layout */
 .hero-grid {
   display: grid;
-  gap: 2rem;
+  gap: 1rem;
 }
 
 @media (min-width: 1024px) {
@@ -39,14 +45,20 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 1.5rem;
+  gap: 1rem;
+}
+
+@media (min-width: 1024px) {
+  .hero-left-column {
+    gap: 1.5rem;
+  }
 }
 
 /* Badge */
 .hero-badge {
   display: inline-flex;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.8rem;
   font-weight: 700;
   background-color: #21468B21;
   color: #21468B;
@@ -55,12 +67,19 @@
   backdrop-filter: blur(4px);
 }
 
+@media (min-width: 1024px) {
+  .hero-badge {
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+  }
+}
+
 /* Title */
 .hero-title {
-  font-size: 2.25rem;
+  font-size: clamp(2rem, 11vw, 3rem);
   font-weight: 700;
   letter-spacing: -0.025em;
-  line-height: 1.2;
+  line-height: 1.05;
   color: #21468B;
   text-transform: uppercase;
 }
@@ -85,39 +104,74 @@
 
 /* Description */
 .hero-description {
-  font-size: 1.25rem;
+  font-size: 1rem;
+  line-height: 1.45;
   color: var(--text-muted, #666666);
+}
+
+.hero-short-description {
+  color: #21468B;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.hero-detail-description {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .hero-description {
+    font-size: 1.25rem;
+  }
+
+  .hero-detail-description {
+    display: block;
+  }
 }
 
 /* Feature List */
 .hero-feature-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgb(33 70 139 / 14%);
+}
+
+@media (min-width: 768px) {
+  .hero-feature-list {
+    gap: 0.75rem;
+    padding-top: 0;
+    border-top: 0;
+  }
 }
 
 .hero-feature-item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
   color: var(--text-muted, #666666);
+  font-size: 0.95rem;
 }
 
 .hero-icon {
+  flex: 0 0 auto;
   height: 1.25rem;
   width: 1.25rem;
 }
 
 /* CTA Container */
 .hero-cta-container {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.65rem;
 }
 
 @media (min-width: 640px) {
   .hero-cta-container {
-    flex-direction: row;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
   }
 }
 
@@ -132,10 +186,26 @@
   display: none;
 }
 
+.hero-mobile-illustration {
+  width: min(100%, 34rem);
+  height: clamp(7.75rem, 36vw, 9.25rem);
+  margin: -0.75rem auto 0.85rem;
+  overflow: hidden;
+}
+
+.hero-mobile-illustration .gatsby-image-wrapper {
+  display: block;
+  transform: translateY(-18%);
+}
+
 @media (min-width: 1024px) {
   .hero-right-column {
     display: block;
     position: relative;
+  }
+
+  .hero-mobile-illustration {
+    display: none;
   }
 }
 
@@ -208,20 +278,33 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 500;
+  min-height: 44px;
+  padding: 0.72rem 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 700;
   text-align: center;
-  color: white;
   text-decoration: none;
-  background: #FF7900;
   border: 0;
   border-radius: 0.375rem;
   cursor: pointer;
 }
 
+.hero-cta-button--primary {
+  grid-column: 1 / -1;
+  color: white;
+  background: #FF7900;
+}
+
+.hero-cta-button--secondary {
+  color: #21468B;
+  background: #21468B12;
+  border: 1px solid rgb(33 70 139 / 24%);
+}
+
 @media (min-width: 640px) {
   .hero-cta-button {
     width: auto;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
   }
 }

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -10,6 +10,14 @@ const Hero = () => (
 
       <div className="hero-content-container">
         <div className="hero-grid">
+          <div className="hero-mobile-illustration fade-in-scale">
+            <StaticImage
+              src="./images/CND-NL-Buildings.png"
+              alt="Dutch Cloud Native Day buildings"
+              formats={['auto', 'webp']}
+            />
+          </div>
+
           {/* Left column - Content */}
           <div className="hero-left-column fade-in-up">
             {/* Date Badge */}
@@ -19,7 +27,43 @@ const Hero = () => (
             <h1 className="hero-title">Dutch Cloud Native Day</h1>
 
             {/* Description */}
-            <p className="hero-description">
+            <p className="hero-description hero-short-description">
+              Two days of cloud native talks, workshops and community in Utrecht.
+            </p>
+
+            {/* CTA Buttons */}
+            <div className="hero-cta-container">
+              <a
+                href="/#tickets"
+                className="hero-cta-button hero-cta-button--primary"
+                data-goatcounter-click="ticket-click"
+                data-goatcounter-title="Ticket click"
+              >
+                Buy Tickets
+              </a>
+              <a
+                href="https://sessionize.com/dutch-cloud-native-day-2026/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hero-cta-button hero-cta-button--secondary"
+                data-goatcounter-click="cfp-click"
+                data-goatcounter-title="CFP click"
+              >
+                Submit a Talk
+              </a>
+              <a
+                href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hero-cta-button hero-cta-button--secondary"
+                data-goatcounter-click="sponsor-click"
+                data-goatcounter-title="Sponsor click"
+              >
+                Become a Sponsor
+              </a>
+            </div>
+
+            <p className="hero-description hero-detail-description">
               On 29 and 30 October 2026, the cloud native community will gather at Jaarbeurs in
               Utrecht for two full days of talks, workshops and hallway conversations. Come and join
               us!
@@ -45,37 +89,6 @@ const Hero = () => (
               After a great 2025 edition in Utrecht, Dutch Cloud Native Day returns in 2026. See you
               there!
             </p>
-            {/* CTA Buttons */}
-            <div className="hero-cta-container">
-              <a
-                href="https://sessionize.com/dutch-cloud-native-day-2026/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hero-cta-button"
-                data-goatcounter-click="cfp-click"
-                data-goatcounter-title="CFP click"
-              >
-                Submit a Talk
-              </a>
-              <a
-                href="https://drive.google.com/file/d/1pmfb1SrN77O9qqoincRnnVsluhhDmk8e/view"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hero-cta-button"
-                data-goatcounter-click="sponsor-click"
-                data-goatcounter-title="Sponsor click"
-              >
-                Become a Sponsor
-              </a>
-              <a
-                href="/#tickets"
-                className="hero-cta-button"
-                data-goatcounter-click="ticket-click"
-                data-goatcounter-title="Ticket click"
-              >
-                Buy Tickets
-              </a>
-            </div>
           </div>
 
           <div className="hero-right-column fade-in-scale">

--- a/src/components/shared/cookie-consent/cookie-consent.jsx
+++ b/src/components/shared/cookie-consent/cookie-consent.jsx
@@ -164,9 +164,9 @@ const CookieConsent = ({ children }) => {
               <div>
                 <h3>Ticket checkout - Eventbrite</h3>
                 <p>
-                  Loads the embedded Eventbrite checkout. Eventbrite may process personal data and
-                  use cookies or similar technologies for checkout, payment, security, analytics,
-                  and related services.
+                  The only consent-controlled third-party embed on this website is the Eventbrite
+                  checkout. Eventbrite may process personal data and use cookies or similar
+                  technologies for checkout, payment, security, analytics, and related services.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show the DCND buildings illustration at the top of the mobile hero
- move the primary CTAs earlier on mobile and prioritize Buy Tickets
- reduce wasted mobile space by clipping transparent padding around the buildings artwork
- keep GoatCounter outside consent controls while clarifying Eventbrite as the consent-controlled embed
- add Eventbrite ticket checkout notice to the Privacy page

## Validation
- npm run test:analytics
- npx eslint src/components/pages/home/hero/hero.jsx src/components/shared/cookie-consent/cookie-consent.jsx scripts/test-goatcounter-analytics.mjs
- HOME=/private/tmp/dcnd-home npm_config_cache=/private/tmp/dcnd-npm-cache npm run build